### PR TITLE
Adjust for new method for creating a proxy

### DIFF
--- a/GaugeWebsite/node_modules/mongojs/index.js
+++ b/GaugeWebsite/node_modules/mongojs/index.js
@@ -545,7 +545,7 @@ var connect = function(config, collections) {
   });
 
   if (typeof Proxy !== 'undefined') {
-    var p = Proxy.create({
+    var p = new Proxy({},{
       get: function(obj, prop) {
         if (!that[prop]) that[prop] = that.collection(prop);
         return that[prop];

--- a/NodeImap/node_modules/mongojs/index.js
+++ b/NodeImap/node_modules/mongojs/index.js
@@ -545,7 +545,7 @@ var connect = function(config, collections) {
   });
 
   if (typeof Proxy !== 'undefined') {
-    var p = Proxy.create({
+    var p = new Proxy({},{
       get: function(obj, prop) {
         if (!that[prop]) that[prop] = that.collection(prop);
         return that[prop];


### PR DESCRIPTION
`Proxy.create({` is now `new Proxy({},`